### PR TITLE
Support gaufrette both 0.3.x and 0.4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "require": {
     "php": ">=5.6",
     "doctrine/orm": "^2.5",
-    "knplabs/gaufrette": "^0.4",
+    "knplabs/gaufrette": "^0.3|^0.4",
     "knplabs/knp-paginator-bundle": "^2.5",
     "lexik/form-filter-bundle": "^5.0",
     "symfony/asset": "^2.7|^3.0",


### PR DESCRIPTION
Hi,

PR #3 updated [knplabs/gaufrette](https://github.com/KnpLabs/Gaufrette) to ^0.4.
This PR let using gaufrette 0.3.x or 0.4.x