### PR TITLE
FIX Remove 'unversioned' value for parameter `$packageName`

### DIFF
--- a/Storage/Adapter/LocalAdapterConfiguration.php
+++ b/Storage/Adapter/LocalAdapterConfiguration.php
@@ -132,7 +132,7 @@ class LocalAdapterConfiguration extends AbstractAdapterConfiguration implements 
                 $url = sprintf('%s/%s', $this->permanentBaseUrl, $file->getKey());
                 break;
             case StorageUrlResolverInterface::ABSOLUTE_URL:
-                $url = $this->router->getContext()->getScheme() . ':' . $this->assetPackages->getUrl($path, 'unversioned');
+                $url = $this->router->getContext()->getScheme() . ':' . $this->assetPackages->getUrl($path);
                 break;
             default:
                 throw new \LogicException('Undefined url $referenceType');


### PR DESCRIPTION
An exception has been thrown during the rendering of a template ("There is no "unversioned" asset package.").