### PR TITLE
Allow to store file from stream

### DIFF
--- a/Entity/StorageFile.php
+++ b/Entity/StorageFile.php
@@ -133,9 +133,10 @@ class StorageFile extends GaufretteFile
      */
     public function setContent($content, $metadata = array())
     {
+        $size = parent::setContent($content, $metadata);
         $this->contentHash = md5($content);
 
-        return parent::setContent($content, $metadata);
+        return $size;
     }
 
     /**

--- a/Storage/StorageManagerInterface.php
+++ b/Storage/StorageManagerInterface.php
@@ -5,6 +5,7 @@ namespace Opensoft\StorageBundle\Storage;
 use Gaufrette\Filesystem;
 use Opensoft\StorageBundle\Entity\Storage;
 use Opensoft\StorageBundle\Entity\StorageFile;
+use Psr\Http\Message\StreamInterface;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -25,10 +26,38 @@ interface StorageManagerInterface
     public function getFilesystemForStorage(Storage $storage);
 
     /**
+     * Takes a content and store it in permanent storage
+     * Content might be:
+     * UploadedFile
+     * string - path to local file
+     * StreamInterface - stream containing file contents
+     *
+     * It is the callers responsibility to associate the returned entity with a relation and save it to the database
+     *
+     * options:
+     *
+     * - newFilename: (string) Filename used to generate storage file key
+     * - originalFilename: (string) Filename used to determine extension. And the used to generate storage file key
+     * - metadata: (array) An array of key/value pairs to pass into storage adapter. Note:
+     *   ContentType would be used as StorageFile mime-type
+     *   ContentLength is required in case content is stream
+     * - unlinkAfterStore: (bool) Set to true to unlink temporary stored file after storing to storage.
+     *
+     * @param integer $type
+     * @param UploadedFile|StreamInterface|string $content
+     * @param array $options
+     * @throws \RuntimeException If writing the file fails
+     * @return StorageFile
+     */
+    public function store($type, $content, array $options = []);
+
+    /**
      * Store a file from an upload into the storage engine.
      *
      * It is the callers responsibility to associate the returned entity with a relation and save that relation to the database.  The
      * storage file itself will be independently stored by the storage manager.
+     *
+     * @deprecated Use StorageManagerInterface::store instead
      *
      * @param int $type
      * @param UploadedFile $uploadedFile
@@ -43,6 +72,8 @@ interface StorageManagerInterface
      *
      * It is the callers responsibility to associate the returned entity with a relation and save that relation to the database.  The
      * storage file itself will be independently stored by the storage manager.
+     *
+     * @deprecated Use StorageManagerInterface::store instead
      *
      * @param integer $type
      * @param string $path

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     "symfony/asset": "^2.7|^3.0",
     "symfony/framework-bundle": "^2.7|^3.0",
     "symfony/validator": "^2.7|^3.0",
-    "twig/twig": "^1.25|^2.0"
+    "twig/twig": "^1.25|^2.0",
+    "psr/http-message": "^1.0"
   },
   "require-dev": {
     "aws/aws-sdk-php": "^3.29",


### PR DESCRIPTION
- Added a new parameter to Aws adapter configuration - 'signature_version'. Needed to disable retrieving the whole body before uploading to AWS S3.
- Changed ordering in StorageFile::setContent. Calculate size after we set content, this allows to first stream content to AWS S3 and then after we have all data in memory calculate the content size.
- Added new method StorageManager::storeStream. $stream parameter should be a string or StreamInterface (not described in phpdoc because it will require adding a dependency on psr\http-message)
