### PR TITLE
Allow to accept file stored in filesystem

### DIFF
--- a/Storage/StorageManagerInterface.php
+++ b/Storage/StorageManagerInterface.php
@@ -132,4 +132,33 @@ interface StorageManagerInterface
      * @return StreamedResponse|BinaryFileResponse
      */
     public function returnStorageFileDownloadResponse(StorageFile $storageFile, array $additionalHeaders = [], $isInlineDisposition = false);
+
+    /**
+     * Accept and save to database file already stored in filesystem
+     *
+     * options:
+     *
+     * - contentHash: (string) File contents md5 hash
+     * - size: (int) File size in bytes
+     * - mimeType: (string) File mime type
+     * - metadata: (array) An array of key/value pairs to pass into storage adapter.
+     *
+     * @param integer $type
+     * @param string $key
+     * @param array $options
+     * @return StorageFile
+     */
+    public function accept($type, $key, array $options = []);
+
+    /**
+     * Issue new key to store file directly to storage filesystem and accept it later into storage database.
+     *
+     * options:
+     *
+     * - newFilename: (string) Filename used to generate storage file key
+     *
+     * @param array $options
+     * @return string
+     */
+    public function issueNewKey(array $options = []);
 }


### PR DESCRIPTION
We have use cases where files could be stored in the target filesystem with technology different from PHP (e.g. Java on AWS Lambda). In order to optimize the whole workflow, we would like to be able to accept to StorageBundle files already stored on a filesystem. 

This implementation introduces two new methods: 
`public function accept($type, $key, array $options = []);`
and
`public function issueNewKey(array $options = []);`

Another way of implementing this feature would be to store somewhere issued keys so that they could be checked later to clean up storage filesystem from files that were uploaded but not accepted.