### PR TITLE
Allow to hash stream on setContent

### DIFF
--- a/Storage/HashingStream.php
+++ b/Storage/HashingStream.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Opensoft\StorageBundle\Storage;
+
+use GuzzleHttp\Psr7\StreamDecoratorTrait;
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * Stream decorator that calculates a rolling hash of the stream as it is read.
+ *
+ * Simplified version inspired by https://github.com/aws/aws-sdk-php/blob/master/src/HashingStream.php
+ */
+class HashingStream implements StreamInterface
+{
+    use StreamDecoratorTrait;
+
+    const HASH_ALGORITHM = 'md5';
+
+    /**
+     * @var \HashContext
+     */
+    private $context;
+
+    /**
+     * @var string
+     */
+    private $hash;
+
+    /**
+     * @var callable
+     */
+    private $callback;
+
+    /**
+     * @param StreamInterface $stream     Stream that is being read.
+     * @param callable        $onComplete Function invoked when the
+     *                                    hash calculation is completed.
+     */
+    public function __construct(StreamInterface $stream, callable $onComplete) {
+        $this->stream = $stream;
+        $this->callback = $onComplete;
+    }
+
+    public function read($length)
+    {
+        $data = $this->stream->read($length);
+        if ($this->hash === null) {
+            hash_update($this->getContext(), $data);
+            if ($this->eof()) {
+                $this->hash = hash_final($this->getContext());
+                call_user_func($this->callback, $this->hash);
+            }
+        }
+
+        return $data;
+    }
+
+    public function seek($offset, $whence = SEEK_SET)
+    {
+        if ($offset === 0) {
+            $this->reset();
+            return $this->stream->seek($offset);
+        } else {
+            // Seeking arbitrarily is not supported.
+            return false;
+        }
+    }
+
+    private function getContext()
+    {
+        if ($this->context === null) {
+            $this->context = hash_init(self::HASH_ALGORITHM);
+        }
+
+        return $this->context;
+    }
+
+    private function reset()
+    {
+        $this->hash = $this->context = null;
+    }
+}

--- a/Tests/Storage/StorageFileTest.php
+++ b/Tests/Storage/StorageFileTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Opensoft\StorageBundle\Tests\Storage;
+
+
+use Gaufrette\Filesystem;
+use function GuzzleHttp\Psr7\stream_for;
+use GuzzleHttp\Psr7\StreamWrapper;
+use Opensoft\StorageBundle\Entity\Storage;
+use Opensoft\StorageBundle\Entity\StorageFile;
+use Opensoft\StorageBundle\Storage\Gaufrette\Adapter\Local;
+
+class StorageFileTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var StorageFile
+     */
+    private $file;
+
+    /** @var string */
+    private $directory;
+    /** @var string */
+    private $key;
+
+    protected function setUp()
+    {
+        $this->directory = sys_get_temp_dir() . '/test';
+        $this->key = 'test.txt';
+
+        $filesystem = new Filesystem(new Local($this->directory, true));
+
+        $this->file = new StorageFile($this->key, $filesystem, new Storage());
+    }
+
+    public function testContentCanBeSetAsString()
+    {
+        $expected = 'here is my content';
+        $this->file->setContent($expected);
+
+        $this->assertFileContent($expected);
+    }
+
+    public function testContentCanBeSetAsStream()
+    {
+        $expected = 'here is my content';
+        $this->file->setContent(stream_for($expected));
+
+        $this->assertFileContent($expected);
+    }
+
+    public function testContentCanBeSetAsResource()
+    {
+        $expected = 'here is my content';
+        $this->file->setContent(StreamWrapper::getResource(stream_for($expected)));
+
+        $this->assertFileContent($expected);
+    }
+
+    private function assertFileContent($expected)
+    {
+        $this->assertEquals($expected, (string)$this->file->getContent());
+        $this->assertEquals(md5($expected), $this->file->getContentHash());
+
+        $this->assertEquals($expected, file_get_contents($this->directory . '/' . $this->key));
+    }
+}

--- a/Tests/Storage/StorageManagerTest.php
+++ b/Tests/Storage/StorageManagerTest.php
@@ -4,7 +4,6 @@ namespace Opensoft\StorageBundle\Tests\Storage;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityManager;
-use GuzzleHttp\Psr7\Stream;
 use function GuzzleHttp\Psr7\stream_for;
 use Opensoft\StorageBundle\Entity\Repository\StoragePolicyRepository;
 use Opensoft\StorageBundle\Entity\Repository\StorageRepository;

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
     "symfony/framework-bundle": "^2.7|^3.0",
     "symfony/validator": "^2.7|^3.0",
     "twig/twig": "^1.25|^2.0",
-    "psr/http-message": "^1.0"
+    "psr/http-message": "^1.0",
+    "guzzlehttp/psr7": "^1.4.1"
   },
   "require-dev": {
     "aws/aws-sdk-php": "^3.29",


### PR DESCRIPTION
Hash content using a stream instead of full content. This allows us to pass resource as content and reduce memory usage.
Most of the underlying filesystem adapters should support resources.

Conversion from and to stream is done by guzzlehttp/psr7 library.
