### PR TITLE
Track move exceptions with a new table

### DIFF
--- a/Entity/Repository/StorageMoveExceptionRepository.php
+++ b/Entity/Repository/StorageMoveExceptionRepository.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * This file is part of ONP.
+ *
+ * Copyright (c) Opensoft (http://opensoftdev.com)
+ *
+ * The unauthorized use of this code outside the boundaries of
+ * Opensoft is prohibited.
+ */
+
+namespace Opensoft\StorageBundle\Entity\Repository;
+
+use Doctrine\ORM\EntityRepository;
+
+/**
+ * @author Richard Fullmer <richard.fullmer@opensoftdev.com>
+ */
+class StorageMoveExceptionRepository extends EntityRepository
+{
+
+}

--- a/Entity/StorageFile.php
+++ b/Entity/StorageFile.php
@@ -2,6 +2,7 @@
 
 namespace Opensoft\StorageBundle\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Gaufrette\File as GaufretteFile;
 use Gaufrette\Filesystem;
@@ -81,6 +82,14 @@ class StorageFile extends GaufretteFile
     private $contentHash;
 
     /**
+     * @var StorageMoveException[]
+     *
+     * @ORM\OneToMany(targetEntity="Opensoft\StorageBundle\Entity\StorageMoveException", mappedBy="storageFile")
+     * @ORM\OrderBy({"createdAt" = "DESC"})
+     */
+    private $moveExceptions;
+
+    /**
      * Constructor
      *
      * @param string $key
@@ -92,6 +101,7 @@ class StorageFile extends GaufretteFile
         parent::__construct($key, $filesystem);
         $this->storage = $storage;
         $this->createdAt = new \DateTime();
+        $this->moveExceptions = new ArrayCollection();
     }
 
     /**
@@ -259,6 +269,14 @@ class StorageFile extends GaufretteFile
     public function setType($type)
     {
         $this->type = $type;
+    }
+
+    /**
+     * @return ArrayCollection|StorageMoveException[]
+     */
+    public function getMoveExceptions()
+    {
+        return $this->moveExceptions;
     }
 
     /**

--- a/Entity/StorageMoveException.php
+++ b/Entity/StorageMoveException.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * This file is part of ONP.
+ *
+ * Copyright (c) Opensoft (http://opensoftdev.com)
+ *
+ * The unauthorized use of this code outside the boundaries of
+ * Opensoft is prohibited.
+ */
+
+namespace Opensoft\StorageBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @author Richard Fullmer <richard.fullmer@opensoftdev.com>
+ *
+ * @ORM\Entity(repositoryClass="Opensoft\StorageBundle\Entity\Repository\StorageMoveExceptionRepository")
+ * @ORM\Table(name="storage_move_exception")
+ */
+class StorageMoveException
+{
+    /**
+     * @var int
+     *
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @var StorageFile
+     *
+     * @ORM\ManyToOne(targetEntity="Opensoft\StorageBundle\Entity\StorageFile", inversedBy="moveExceptions")
+     * @ORM\JoinColumn(name="storage_file_id", referencedColumnName="id", nullable=false, onDelete="CASCADE")
+     */
+    private $storageFile;
+
+    /**
+     * @var Storage
+     *
+     * @ORM\ManyToOne(targetEntity="Opensoft\StorageBundle\Entity\Storage")
+     * @ORM\JoinColumn(name="from_storage_id", referencedColumnName="id", nullable=false, onDelete="CASCADE")
+     */
+    private $fromStorage;
+
+    /**
+     * @var Storage
+     *
+     * @ORM\ManyToOne(targetEntity="Opensoft\StorageBundle\Entity\Storage")
+     * @ORM\JoinColumn(name="to_storage_id", referencedColumnName="id", nullable=false, onDelete="CASCADE")
+     */
+    private $toStorage;
+
+    /**
+     * @var \DateTime
+     *
+     * @ORM\Column(type="datetime", name="created_at")
+     */
+    private $createdAt;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(type="string", name="exception_string")
+     */
+    private $exceptionString;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(type="text", name="exception_backtrace")
+     */
+    private $exceptionBacktrace;
+
+    /**
+     * @param StorageFile $file
+     * @param Storage $fromStorage
+     * @param Storage $toStorage
+     * @param \Exception $e
+     */
+    public function __construct(StorageFile $file, Storage $fromStorage, Storage $toStorage, \Exception $e)
+    {
+        $this->storageFile = $file;
+        $this->fromStorage = $fromStorage;
+        $this->toStorage = $toStorage;
+        $this->createdAt = new \DateTime();
+        $this->exceptionString = $e->getMessage();
+        $this->exceptionBacktrace = $e->getTraceAsString();
+    }
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return StorageFile
+     */
+    public function getStorageFile()
+    {
+        return $this->storageFile;
+    }
+
+    /**
+     * @return Storage
+     */
+    public function getFromStorage()
+    {
+        return $this->fromStorage;
+    }
+
+    /**
+     * @return Storage
+     */
+    public function getToStorage()
+    {
+        return $this->toStorage;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getCreatedAt()
+    {
+        return $this->createdAt;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExceptionString()
+    {
+        return $this->exceptionString;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExceptionBacktrace()
+    {
+        return $this->exceptionBacktrace;
+    }
+}

--- a/Resources/views/storage/show_file.html.twig
+++ b/Resources/views/storage/show_file.html.twig
@@ -175,6 +175,40 @@
             </div>
         </div>
     </div>
+
+    {% if file.moveExceptions %}
+    <div class="row">
+        <div class="col-lg-12">
+            <div class="ibox">
+                <div class="ibox-title">
+                    <h5>Move Exceptions <i class="fa fa-warning"></i></h5>
+                </div>
+                <div class="ibox-content">
+                    <div class="table-responsive">
+                        <table class="table table-hover">
+                            <thead>
+                                <tr>
+                                    <th>Timestamp</th>
+                                    <th>From Storage</th>
+                                    <th>To Storage</th>
+                                    <th>Exception</th>
+                                </tr>
+                            </thead>
+                            {% for moveException in file.moveExceptions %}
+                            <tr>
+                                <td>{{ moveException.createdAt|date }}</td>
+                                <td>{{ moveException.fromStorage.name }}</td>
+                                <td>{{ moveException.toStorage.name }}</td>
+                                <td><p title="{{ moveException.exceptionBacktrace }}">{{ moveException.exceptionString }}</p></td>
+                            </tr>
+                            {% endfor %}
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    {% endif %}
 {% endblock %}
 
 {% block opensoft_storage_foot_script %}


### PR DESCRIPTION
This will track move exceptions with an independent table.  Additionally, the policy mover will now ignore storage files that have move exceptions as it will assume those cannot be moved.

The view storage file page also will now list any move exceptions associated with that storage file.

![image](https://user-images.githubusercontent.com/384602/50614977-8d995e80-0e97-11e9-8d45-28ba0d639410.png)

Potential issues to watch for - 

* There's no way to clear a move exception except manually
* No automated way to look at why a move exception happened